### PR TITLE
Deactivate cache

### DIFF
--- a/SimpleFileDownloader/src/main/java/org/vaadin/simplefiledownloader/SimpleFileDownloader.java
+++ b/SimpleFileDownloader/src/main/java/org/vaadin/simplefiledownloader/SimpleFileDownloader.java
@@ -123,6 +123,7 @@ public class SimpleFileDownloader extends AbstractExtension {
             }
             stream = ((ConnectorResource) resource).getStream();
 
+            stream.setParameter("Cache-Control", "no-store");
             String contentDisposition = stream
                     .getParameter(DownloadStream.CONTENT_DISPOSITION);
             if (contentDisposition == null) {

--- a/SimpleFileDownloader/src/test/java/org/vaadin/simplefiledownloader/MySimpleFileDownloaderTest.java
+++ b/SimpleFileDownloader/src/test/java/org/vaadin/simplefiledownloader/MySimpleFileDownloaderTest.java
@@ -9,17 +9,6 @@ import org.vaadin.simplefiledownloader.SimpleFileDownloader;
 
 import java.io.ByteArrayInputStream;
 
-/**
- * <p><b>simplefiledownloaderaddon</b></p>
- * <p>Aufgabe der Klasse</p>
- * <br><tt>History:<ul>
- * <li>27.03.2017 angelegt</li>
- * </ul>
- * <p>Copyright: 2017</p>
- * <p>Organisation: ABDATA</p>
- *
- * @author pn
- */
 public class MySimpleFileDownloaderTest extends AbstractTest {
 
     @Override


### PR DESCRIPTION
We should set the cache control to no-store like in issue #3 mentioned . Necessary for dynamic file downloads like e.g. grid export...
